### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/functions/fonts.install.fish
+++ b/functions/fonts.install.fish
@@ -18,7 +18,7 @@ function fonts.install
     return 1
   end
 
-  if set tmpdir (mktemp -d "/tmp/font-$name.XXXXXX" ^&-)
+  if set tmpdir (mktemp -d "/tmp/font-$name.XXXXXX" 2>&-)
     if not set download_urls (__fonts.repo.urls $name $filter)
       printf "No %s$name%s font found. Try using %s--powerline%s option.\n" \
              (set_color -o) (set_color normal) (set_color -o) (set_color normal)
@@ -38,7 +38,7 @@ function fonts.install
 
     mkdir -p $FONTS_PATH
 
-    if not mv $tmpdir/* $FONTS_PATH ^&-
+    if not mv $tmpdir/* $FONTS_PATH 2>&-
       rm -rf $FONTS_CONFIG/$name
       rm -rf $tmpdir
       echo 'Error installing font files'

--- a/functions/fonts.remove.fish
+++ b/functions/fonts.remove.fish
@@ -6,5 +6,5 @@ function fonts.remove -a name
   end
 
   rm -rv $FONTS_PATH/(cat $target)
-  rm -f $target ^&-
+  rm -f $target 2>&-
 end


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
